### PR TITLE
Tarea 2

### DIFF
--- a/modules/weatherinfo/Readme.md
+++ b/modules/weatherinfo/Readme.md
@@ -1,0 +1,1 @@
+# Show users weather info

--- a/modules/weatherinfo/config.xml
+++ b/modules/weatherinfo/config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<module>
+	<name>weatherinfo</name>
+	<displayName><![CDATA[Show users weather info]]></displayName>
+	<version><![CDATA[1.0.0]]></version>
+	<description><![CDATA[Module that shows users info about the weather]]></description>
+	<author><![CDATA[Tomas Carrasco]]></author>
+	<tab><![CDATA[front_office_features]]></tab>
+	<is_configurable>1</is_configurable>
+	<need_instance>1</need_instance>
+</module>

--- a/modules/weatherinfo/index.php
+++ b/modules/weatherinfo/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/modules/weatherinfo/sql/index.php
+++ b/modules/weatherinfo/sql/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/modules/weatherinfo/sql/install.php
+++ b/modules/weatherinfo/sql/install.php
@@ -1,0 +1,37 @@
+<?php
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+$sql = array();
+
+$sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'weatherinfo` (
+    `id_weatherinfo` int(11) NOT NULL AUTO_INCREMENT,
+    PRIMARY KEY  (`id_weatherinfo`)
+) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8;';
+
+foreach ($sql as $query) {
+    if (Db::getInstance()->execute($query) == false) {
+        return false;
+    }
+}

--- a/modules/weatherinfo/sql/uninstall.php
+++ b/modules/weatherinfo/sql/uninstall.php
@@ -1,0 +1,38 @@
+<?php
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+
+/**
+ * In some cases you should not drop the tables.
+ * Maybe the merchant will just try to reset the module
+ * but does not want to loose all of the data associated to the module.
+ */
+$sql = array();
+
+foreach ($sql as $query) {
+    if (Db::getInstance()->execute($query) == false) {
+        return false;
+    }
+}

--- a/modules/weatherinfo/translations/index.php
+++ b/modules/weatherinfo/translations/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/modules/weatherinfo/upgrade/index.php
+++ b/modules/weatherinfo/upgrade/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/modules/weatherinfo/upgrade/upgrade-1.1.0.php
+++ b/modules/weatherinfo/upgrade/upgrade-1.1.0.php
@@ -1,0 +1,43 @@
+<?php
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * This function updates your module from previous versions to the version 1.1,
+ * usefull when you modify your database, or register a new hook ...
+ * Don't forget to create one file per version.
+ */
+function upgrade_module_1_1_0($module)
+{
+    /*
+     * Do everything you want right there,
+     * You could add a column in one of your module's tables
+     */
+
+    return true;
+}

--- a/modules/weatherinfo/views/css/back.css
+++ b/modules/weatherinfo/views/css/back.css
@@ -1,0 +1,27 @@
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*
+* Don't forget to prefix your containers with your own identifier
+* to avoid any conflicts with others containers.
+*/

--- a/modules/weatherinfo/views/css/front.css
+++ b/modules/weatherinfo/views/css/front.css
@@ -1,0 +1,27 @@
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*
+* Don't forget to prefix your containers with your own identifier
+* to avoid any conflicts with others containers.
+*/

--- a/modules/weatherinfo/views/css/front.css
+++ b/modules/weatherinfo/views/css/front.css
@@ -25,3 +25,9 @@
 * Don't forget to prefix your containers with your own identifier
 * to avoid any conflicts with others containers.
 */
+
+.nav-weather-info {
+    font-size: .875rem;
+    font-weight: 400;
+    color: #232323;
+}

--- a/modules/weatherinfo/views/css/front.css
+++ b/modules/weatherinfo/views/css/front.css
@@ -31,3 +31,8 @@
     font-weight: 400;
     color: #232323;
 }
+
+#weatherinfo-nav-2 {
+    margin-top: auto;
+    margin-bottom: auto;
+}

--- a/modules/weatherinfo/views/css/index.php
+++ b/modules/weatherinfo/views/css/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/modules/weatherinfo/views/img/index.php
+++ b/modules/weatherinfo/views/img/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/modules/weatherinfo/views/index.php
+++ b/modules/weatherinfo/views/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/modules/weatherinfo/views/js/back.js
+++ b/modules/weatherinfo/views/js/back.js
@@ -1,0 +1,27 @@
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*
+* Don't forget to prefix your containers with your own identifier
+* to avoid any conflicts with others containers.
+*/

--- a/modules/weatherinfo/views/js/front.js
+++ b/modules/weatherinfo/views/js/front.js
@@ -1,0 +1,27 @@
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*
+* Don't forget to prefix your containers with your own identifier
+* to avoid any conflicts with others containers.
+*/

--- a/modules/weatherinfo/views/js/index.php
+++ b/modules/weatherinfo/views/js/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/modules/weatherinfo/views/templates/admin/configure.tpl
+++ b/modules/weatherinfo/views/templates/admin/configure.tpl
@@ -1,0 +1,48 @@
+{*
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*}
+
+<div class="panel">
+	<h3><i class="icon icon-credit-card"></i> {l s='Show users weather info' mod='weatherinfo'}</h3>
+	<p>
+		<strong>{l s='Here is my new generic module!' mod='weatherinfo'}</strong><br />
+		{l s='Thanks to PrestaShop, now I have a great module.' mod='weatherinfo'}<br />
+		{l s='I can configure it using the following configuration form.' mod='weatherinfo'}
+	</p>
+	<br />
+	<p>
+		{l s='This module will boost your sales!' mod='weatherinfo'}
+	</p>
+</div>
+
+<div class="panel">
+	<h3><i class="icon icon-tags"></i> {l s='Documentation' mod='weatherinfo'}</h3>
+	<p>
+		&raquo; {l s='You can get a PDF documentation to configure this module' mod='weatherinfo'} :
+		<ul>
+			<li><a href="#" target="_blank">{l s='English' mod='weatherinfo'}</a></li>
+			<li><a href="#" target="_blank">{l s='French' mod='weatherinfo'}</a></li>
+		</ul>
+	</p>
+</div>

--- a/modules/weatherinfo/views/templates/admin/index.php
+++ b/modules/weatherinfo/views/templates/admin/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/modules/weatherinfo/views/templates/hook/nav_1.tpl
+++ b/modules/weatherinfo/views/templates/hook/nav_1.tpl
@@ -1,0 +1,9 @@
+<div class="nav-weather-info">
+    {if $weatherinfo}
+        <span>
+            <img src="https://openweathermap.org/img/wn/{$weatherinfo.icon}@2x.png" alt="Weather icon" style="height:24px;"> {$weatherinfo.country} - {$weatherinfo.city} - {$weatherinfo.temp}°C - {$weatherinfo.humidity}%
+        </span>
+    {else}
+        <span>{l s='There is not weather information available.' mod='weatherinfo'}</span>
+    {/if}
+</div>

--- a/modules/weatherinfo/views/templates/hook/nav_2.tpl
+++ b/modules/weatherinfo/views/templates/hook/nav_2.tpl
@@ -1,0 +1,9 @@
+<div class="nav-weather-info mt-1">
+    {if $weatherinfo}
+        <span>
+            <img src="https://openweathermap.org/img/wn/{$weatherinfo.icon}@2x.png" alt="Weather icon" style="height:24px;"> {$weatherinfo.countryCode} - {$weatherinfo.city} - {$weatherinfo.temp}°C - {$weatherinfo.humidity}%
+        </span>
+    {else}
+        <span>{l s='There is not weather information available.' mod='weatherinfo'}</span>
+    {/if}
+</div>

--- a/modules/weatherinfo/views/templates/hook/nav_full_width.tpl
+++ b/modules/weatherinfo/views/templates/hook/nav_full_width.tpl
@@ -2,21 +2,13 @@
     {if $weatherinfo}
         <div class="row">
             <div class="col-md-12">
-                <h2>{l s='Weather Information' mod='weatherinfo'}</h2>
-            </div>
-        </div>
-        <div class="row">
-            <div class="col-md-12">
-                <p>{l s='City:' mod='weatherinfo'} {$weatherinfo.city}</p>
-                <p>{l s='Country:' mod='weatherinfo'} {$weatherinfo.country}</p>
-                <p>{l s='Temp:' mod='weatherinfo'} {$weatherinfo.temp}°C</p>
-                <p>{l s='Humidity:' mod='weatherinfo'} {$weatherinfo.humidity}%</p>
+                <p><img src="https://openweathermap.org/img/wn/{$weatherinfo.icon}@2x.png" alt="Weather icon" style="height:24px;"> {$weatherinfo.countryCode} - {$weatherinfo.city} - {$weatherinfo.temp}°C - {$weatherinfo.humidity}%</p>
             </div>
         </div>
     {else}
         <div class="row">
             <div class="col-md-12">
-                <h2>{l s='There is not weather information available.' mod='weatherinfo'}</h2>
+                <p>{l s='There is not weather information available.' mod='weatherinfo'}</p>
             </div>
         </div>
     {/if}

--- a/modules/weatherinfo/views/templates/hook/nav_full_width.tpl
+++ b/modules/weatherinfo/views/templates/hook/nav_full_width.tpl
@@ -1,0 +1,23 @@
+<div class="container">
+    {if $weatherinfo}
+        <div class="row">
+            <div class="col-md-12">
+                <h2>{l s='Weather Information' mod='weatherinfo'}</h2>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md-12">
+                <p>{l s='City:' mod='weatherinfo'} {$weatherinfo.city}</p>
+                <p>{l s='Country:' mod='weatherinfo'} {$weatherinfo.country}</p>
+                <p>{l s='Temp:' mod='weatherinfo'} {$weatherinfo.temp}°C</p>
+                <p>{l s='Humidity:' mod='weatherinfo'} {$weatherinfo.humidity}%</p>
+            </div>
+        </div>
+    {else}
+        <div class="row">
+            <div class="col-md-12">
+                <h2>{l s='There is not weather information available.' mod='weatherinfo'}</h2>
+            </div>
+        </div>
+    {/if}
+</div>

--- a/modules/weatherinfo/views/templates/hook/top.tpl
+++ b/modules/weatherinfo/views/templates/hook/top.tpl
@@ -1,4 +1,4 @@
-<div class="nav-weather-info" id="weatherinfo-nav-2">
+<div class="nav-weather-info mt-1 pl-2">
     {if $weatherinfo}
         <span>
             <img src="https://openweathermap.org/img/wn/{$weatherinfo.icon}@2x.png" alt="Weather icon" style="height:24px;"> {$weatherinfo.countryCode} - {$weatherinfo.city} - {$weatherinfo.temp}°C - {$weatherinfo.humidity}%

--- a/modules/weatherinfo/views/templates/index.php
+++ b/modules/weatherinfo/views/templates/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/modules/weatherinfo/weatherinfo.php
+++ b/modules/weatherinfo/weatherinfo.php
@@ -64,6 +64,8 @@ class Weatherinfo extends Module
 
         return parent::install() &&
             $this->registerHook('header') &&
+            $this->registerHook('displayNav1') &&
+            $this->registerHook('displayNav2') &&
             $this->registerHook('displayNavFullWidth');
     }
 
@@ -219,6 +221,28 @@ class Weatherinfo extends Module
         return $this->display(__FILE__, 'views/templates/hook/nav_full_width.tpl');
     }
 
+    public function hookDisplayNav1($params)
+    {
+        // Assign to Smarty
+        $this->context->smarty->assign([
+            'weatherinfo' => $this->getWeatherInfo(Tools::getRemoteAddr()),
+        ]);
+
+        // Render a template (create this file in your module)
+        return $this->display(__FILE__, 'views/templates/hook/nav_1.tpl');
+    }
+
+    public function hookDisplayNav2($params)
+    {
+        // Assign to Smarty
+        $this->context->smarty->assign([
+            'weatherinfo' => $this->getWeatherInfo(Tools::getRemoteAddr()),
+        ]);
+
+        // Render a template (create this file in your module)
+        return $this->display(__FILE__, 'views/templates/hook/nav_2.tpl');
+    }
+
     /**
      * Get the weather information based on the user's IP address.
      * @param string $ip The user's IP address.
@@ -236,7 +260,6 @@ class Weatherinfo extends Module
             $geo = json_decode(file_get_contents("http://ip-api.com/json/$ip"), true);
 
             if ($geo && $geo['status'] === 'success') {
-
                 $lat = $geo['lat'];
                 $lon = $geo['lon'];
 
@@ -248,8 +271,10 @@ class Weatherinfo extends Module
                 $weatherData = array(
                     'city' => $geo['city'],
                     'country' => $geo['country'],
+                    'countryCode' => $geo['countryCode'],
                     'temp' => $weather['current']['temp'],
                     'humidity' => $weather['current']['humidity'],
+                    'icon' => $weather["current"]['weather'][0]['icon'],
                 );
 
                 // Store in cache for the configured number of hours

--- a/modules/weatherinfo/weatherinfo.php
+++ b/modules/weatherinfo/weatherinfo.php
@@ -1,0 +1,210 @@
+<?php
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class Weatherinfo extends Module
+{
+    protected $config_form = false;
+
+    public function __construct()
+    {
+        $this->name = 'weatherinfo';
+        $this->tab = 'front_office_features';
+        $this->version = '1.0.0';
+        $this->author = 'Tomas Carrasco';
+        $this->need_instance = 0;
+
+        /**
+         * Set $this->bootstrap to true if your module is compliant with bootstrap (PrestaShop 1.6)
+         */
+        $this->bootstrap = true;
+
+        parent::__construct();
+
+        $this->displayName = $this->l('Show users weather info');
+        $this->description = $this->l('Module that shows users info about the weather');
+
+        $this->ps_versions_compliancy = array('min' => '8.0', 'max' => _PS_VERSION_);
+    }
+
+    /**
+     * Don't forget to create update methods if needed:
+     * http://doc.prestashop.com/display/PS16/Enabling+the+Auto-Update
+     */
+    public function install()
+    {
+        Configuration::updateValue('WEATHERINFO_HOURS_IN_CACHE', 24);
+        Configuration::updateValue('WEATHERINFO_OPEN_WEATHER_KEY', '');
+
+        return parent::install() &&
+            $this->registerHook('header') &&
+            $this->registerHook('displayNavFullWidth');
+    }
+
+    public function uninstall()
+    {
+        Configuration::deleteByName('WEATHERINFO_HOURS_IN_CACHE');
+        Configuration::deleteByName('WEATHERINFO_OPEN_WEATHER_KEY');
+
+        return parent::uninstall();
+    }
+
+    /**
+     * Load the configuration form
+     */
+    public function getContent()
+    {
+        $output = '';
+
+        if (Tools::isSubmit('submit_weatherinfo_config')) {
+            $hours_in_cache = (float)Tools::getValue('WEATHERINFO_HOURS_IN_CACHE');
+            $api_key = Tools::getValue('WEATHERINFO_OPEN_WEATHER_KEY');
+
+            Configuration::updateValue('WEATHERINFO_HOURS_IN_CACHE', $hours_in_cache);
+            Configuration::updateValue('WEATHERINFO_OPEN_WEATHER_KEY', $api_key);
+
+            $output .= $this->displayConfirmation($this->l('Settings updated'));
+        }
+
+        $output .= $this->renderForm();
+        return $output;
+    }
+
+    /**
+     * Create the form that will be displayed in the configuration of your module.
+     */
+    protected function renderForm()
+    {
+        $default_lang = (int)Configuration::get('PS_LANG_DEFAULT');
+
+        $fields_form[0]['form'] = [
+            'legend' => [
+                'title' => $this->l('Weather Info Settings'),
+            ],
+            'input' => [
+                [
+                    'type' => 'text',
+                    'label' => $this->l('Hours in Cache'),
+                    'name' => 'WEATHERINFO_HOURS_IN_CACHE',
+                    'required' => true,
+                    'desc' => $this->l('Number of hours to cache weather data (can be decimal, e.g., 1.5)'),
+                ],
+                [
+                    'type' => 'text',
+                    'label' => $this->l('OpenWeatherMap API Key'),
+                    'name' => 'WEATHERINFO_OPEN_WEATHER_KEY',
+                    'required' => true,
+                    'desc' => $this->l('Your OpenWeatherMap API key'),
+                ],
+            ],
+            'submit' => [
+                'title' => $this->l('Save'),
+                'class' => 'btn btn-default pull-right'
+            ]
+        ];
+
+        $helper = new HelperForm();
+        $helper->module = $this;
+        $helper->name_controller = $this->name;
+        $helper->token = Tools::getAdminTokenLite('AdminModules');
+        $helper->currentIndex = AdminController::$currentIndex.'&configure='.$this->name;
+        $helper->default_form_language = $default_lang;
+        $helper->allow_employee_form_lang = $default_lang;
+        $helper->title = $this->displayName;
+        $helper->show_cancel_button = false;
+        $helper->submit_action = 'submit_weatherinfo_config';
+
+        // Load current values
+        $helper->fields_value['WEATHERINFO_HOURS_IN_CACHE'] = Configuration::get('WEATHERINFO_HOURS_IN_CACHE');
+        $helper->fields_value['WEATHERINFO_OPEN_WEATHER_KEY'] = Configuration::get('WEATHERINFO_OPEN_WEATHER_KEY');
+
+        return $helper->generateForm($fields_form);
+    }
+
+    /**
+     * Create the structure of your form.
+     */
+    protected function getConfigForm()
+    {
+        return array(
+            'form' => array(
+                'legend' => array(
+                'title' => $this->l('Settings'),
+                'icon' => 'icon-cogs',
+                ),
+                'input' => array(
+                    array(
+                        'type' => 'switch',
+                        'label' => $this->l('Live mode'),
+                        'name' => 'WEATHERINFO_LIVE_MODE',
+                        'is_bool' => true,
+                        'desc' => $this->l('Use this module in live mode'),
+                        'values' => array(
+                            array(
+                                'id' => 'active_on',
+                                'value' => true,
+                                'label' => $this->l('Enabled')
+                            ),
+                            array(
+                                'id' => 'active_off',
+                                'value' => false,
+                                'label' => $this->l('Disabled')
+                            )
+                        ),
+                    ),
+                    array(
+                        'col' => 3,
+                        'type' => 'text',
+                        'prefix' => '<i class="icon icon-envelope"></i>',
+                        'desc' => $this->l('Enter a valid email address'),
+                        'name' => 'WEATHERINFO_ACCOUNT_EMAIL',
+                        'label' => $this->l('Email'),
+                    ),
+                    array(
+                        'type' => 'password',
+                        'name' => 'WEATHERINFO_ACCOUNT_PASSWORD',
+                        'label' => $this->l('Password'),
+                    ),
+                ),
+                'submit' => array(
+                    'title' => $this->l('Save'),
+                ),
+            ),
+        );
+    }
+
+    /**
+     * Add the CSS & JavaScript files you want to be added on the FO.
+     */
+    public function hookHeader()
+    {
+        $this->context->controller->addJS($this->_path.'/views/js/front.js');
+        $this->context->controller->addCSS($this->_path.'/views/css/front.css');
+    }
+}

--- a/modules/weatherinfo/weatherinfo.php
+++ b/modules/weatherinfo/weatherinfo.php
@@ -66,6 +66,7 @@ class Weatherinfo extends Module
             $this->registerHook('header') &&
             $this->registerHook('displayNav1') &&
             $this->registerHook('displayNav2') &&
+            $this->registerHook('displayTop') &&
             $this->registerHook('displayNavFullWidth');
     }
 
@@ -241,6 +242,17 @@ class Weatherinfo extends Module
 
         // Render a template (create this file in your module)
         return $this->display(__FILE__, 'views/templates/hook/nav_2.tpl');
+    }
+
+    public function hookDisplayTop($params)
+    {
+        // Assign to Smarty
+        $this->context->smarty->assign([
+            'weatherinfo' => $this->getWeatherInfo(Tools::getRemoteAddr()),
+        ]);
+
+        // Render a template (create this file in your module)
+        return $this->display(__FILE__, 'views/templates/hook/top.tpl');
     }
 
     /**


### PR DESCRIPTION
### Resumen
Agregar nuevo módulo weatherinfo para PrestaShop 8, que permite mostrar información meteorológica actual en diferentes posiciones de la tienda, configurable desde el back office.
### Funcionalidades
- Permite configurar la API key de OpenWeatherMap y el tiempo de caché en horas desde el panel de administración.
- Permite seleccionar múltiples hooks en donde se mostrará la información del clima (displayNav1, displayNav2 displayNavFullWidth y displayTop).
- Obtención automática de la ubicación del usuario mediante IP y consulta de datos meteorológicos en tiempo real.
- Uso de caché para optimizar el rendimiento y reducir llamadas a la API.
- Textos completamente traducibles.
### Cómo usar
- Instalar el módulo weatherinfo desde el back office.
- Configurar la API key de OpenWeatherMap, el tiempo de caché y los hooks donde se mostrará la información.
- El módulo mostrará el clima actual en las posiciones seleccionadas de la tienda.