### PR TITLE
Tarea 3

### DIFF
--- a/modules/cookiebanner/Readme.md
+++ b/modules/cookiebanner/Readme.md
@@ -1,0 +1,1 @@
+# Cookie banner

--- a/modules/cookiebanner/config.xml
+++ b/modules/cookiebanner/config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<module>
+	<name>cookiebanner</name>
+	<displayName><![CDATA[Cookie banner]]></displayName>
+	<version><![CDATA[1.0.0]]></version>
+	<description><![CDATA[Module that allows to show and personalize a cookie banner]]></description>
+	<author><![CDATA[Tomas Carrasco]]></author>
+	<tab><![CDATA[front_office_features]]></tab>
+	<is_configurable>1</is_configurable>
+	<need_instance>1</need_instance>
+</module>

--- a/modules/cookiebanner/controllers/front/savecookie.php
+++ b/modules/cookiebanner/controllers/front/savecookie.php
@@ -1,0 +1,14 @@
+<?php
+
+
+class CookieBannerSaveCookieModuleFrontController extends ModuleFrontController
+{
+    public function initContent()
+    {
+        parent::initContent();
+
+        $this->context->cookie->cookie_consent = Tools::getValue('consent');
+
+        die(json_encode(['success' => true]));
+    }
+}

--- a/modules/cookiebanner/cookiebanner.php
+++ b/modules/cookiebanner/cookiebanner.php
@@ -71,6 +71,7 @@ class Cookiebanner extends Module
         Configuration::updateValue(self::PREFIX . 'ACCEPT_BTN_COLOR', '');
         Configuration::updateValue(self::PREFIX . 'DECLINE_BTN_COLOR', '');
         Configuration::updateValue(self::PREFIX . 'POSITION', '');
+        Configuration::updateValue(self::PREFIX . 'VISIBLE', 0);
 
         return parent::install() &&
             $this->registerHook('header') &&
@@ -89,6 +90,7 @@ class Cookiebanner extends Module
         Configuration::deleteByName(self::PREFIX . 'ACCEPT_BTN_COLOR');
         Configuration::deleteByName(self::PREFIX . 'DECLINE_BTN_COLOR', '');
         Configuration::deleteByName(self::PREFIX . 'POSITION');
+        Configuration::deleteByName(self::PREFIX . 'VISIBLE');
 
         return parent::uninstall();
     }
@@ -111,6 +113,7 @@ class Cookiebanner extends Module
             Configuration::updateValue(self::PREFIX . 'ACCEPT_BTN_COLOR', Tools::getValue(self::PREFIX . 'ACCEPT_BTN_COLOR'));
             Configuration::updateValue(self::PREFIX . 'DECLINE_BTN_COLOR', Tools::getValue(self::PREFIX . 'DECLINE_BTN_COLOR'));
             Configuration::updateValue(self::PREFIX . 'POSITION', Tools::getValue(self::PREFIX . 'POSITION'));
+            Configuration::updateValue(self::PREFIX . 'VISIBLE', (int)Tools::getValue(self::PREFIX . 'VISIBLE'));
 
             $output .= $this->displayConfirmation($this->l('Settings updated'));
         }
@@ -200,6 +203,25 @@ class Cookiebanner extends Module
                     ],
                     'required' => true,
                 ],
+                [
+                    'type' => 'switch',
+                    'label' => $this->l('Show Cookie Banner'),
+                    'name' => self::PREFIX . 'VISIBLE',
+                    'is_bool' => true,
+                    'desc' => $this->l('Enable or disable the cookie banner.'),
+                    'values' => [
+                        [
+                            'id' => 'active_on',
+                            'value' => 1,
+                            'label' => $this->l('Enabled')
+                        ],
+                        [
+                            'id' => 'active_off',
+                            'value' => 0,
+                            'label' => $this->l('Disabled')
+                        ]
+                    ],
+                ],
             ],
             'submit' => [
                 'title' => $this->l('Save'),
@@ -229,6 +251,7 @@ class Cookiebanner extends Module
         $helper->fields_value[self::PREFIX . 'ACCEPT_BTN_COLOR'] = Configuration::get(self::PREFIX . 'ACCEPT_BTN_COLOR');
         $helper->fields_value[self::PREFIX . 'DECLINE_BTN_COLOR'] = Configuration::get(self::PREFIX . 'DECLINE_BTN_COLOR');
         $helper->fields_value[self::PREFIX . 'POSITION'] = Configuration::get(self::PREFIX . 'POSITION');
+        $helper->fields_value[self::PREFIX . 'VISIBLE'] = Configuration::get(self::PREFIX . 'VISIBLE');
 
         return $helper->generateForm($fields_form);
     }
@@ -244,7 +267,7 @@ class Cookiebanner extends Module
 
     public function hookDisplayFooter($params)
     {
-        if ($this->context->cookie->cookie_consent)
+        if ($this->context->cookie->cookie_consent || !Configuration::get(self::PREFIX . 'VISIBLE'))
             return '';
 
         $config = $this->getModuleConfigValues();
@@ -257,18 +280,18 @@ class Cookiebanner extends Module
     }
 
     public function getModuleConfigValues()
-{
-    return [
-        'text'                      => Configuration::get(self::PREFIX . 'TEXT'),
-        'accept_text'               => Configuration::get(self::PREFIX . 'ACCEPT_TEXT'),
-        'decline_text'              => Configuration::get(self::PREFIX . 'DECLINE_TEXT'),
-        'bg'                        => Configuration::get(self::PREFIX . 'BG'),
-        'text_color'                => Configuration::get(self::PREFIX . 'TEXT_COLOR'),
-        'accept_text_color'         => Configuration::get(self::PREFIX . 'ACCEPT_TEXT_COLOR'),
-        'decline_text_color'        => Configuration::get(self::PREFIX . 'DECLINE_TEXT_COLOR'),
-        'accept_btn_color'          => Configuration::get(self::PREFIX . 'ACCEPT_BTN_COLOR'),
-        'decline_btn_color'         => Configuration::get(self::PREFIX . 'DECLINE_BTN_COLOR'),
-        'position'                  => Configuration::get(self::PREFIX . 'POSITION'),
-    ];
-}
+    {
+        return [
+            'text'                      => Configuration::get(self::PREFIX . 'TEXT'),
+            'accept_text'               => Configuration::get(self::PREFIX . 'ACCEPT_TEXT'),
+            'decline_text'              => Configuration::get(self::PREFIX . 'DECLINE_TEXT'),
+            'bg'                        => Configuration::get(self::PREFIX . 'BG'),
+            'text_color'                => Configuration::get(self::PREFIX . 'TEXT_COLOR'),
+            'accept_text_color'         => Configuration::get(self::PREFIX . 'ACCEPT_TEXT_COLOR'),
+            'decline_text_color'        => Configuration::get(self::PREFIX . 'DECLINE_TEXT_COLOR'),
+            'accept_btn_color'          => Configuration::get(self::PREFIX . 'ACCEPT_BTN_COLOR'),
+            'decline_btn_color'         => Configuration::get(self::PREFIX . 'DECLINE_BTN_COLOR'),
+            'position'                  => Configuration::get(self::PREFIX . 'POSITION'),
+        ];
+    }
 }

--- a/modules/cookiebanner/cookiebanner.php
+++ b/modules/cookiebanner/cookiebanner.php
@@ -1,0 +1,245 @@
+<?php
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class Cookiebanner extends Module
+{
+    protected $config_form = false;
+
+    const PREFIX = 'COOKIEBANNER_BANNER_';
+
+    public function __construct()
+    {
+        $this->name = 'cookiebanner';
+        $this->tab = 'front_office_features';
+        $this->version = '1.0.0';
+        $this->author = 'Tomas Carrasco';
+        $this->need_instance = 0;
+
+        /**
+         * Set $this->bootstrap to true if your module is compliant with bootstrap (PrestaShop 1.6)
+         */
+        $this->bootstrap = true;
+
+        parent::__construct();
+
+        $this->displayName = $this->l('Cookie banner');
+        $this->description = $this->l('Module that allows to show and personalize a cookie banner');
+
+        $this->ps_versions_compliancy = array('min' => '8.0', 'max' => _PS_VERSION_);
+    }
+
+    /**
+     * Don't forget to create update methods if needed:
+     * http://doc.prestashop.com/display/PS16/Enabling+the+Auto-Update
+     */
+    public function install()
+    {
+        Configuration::updateValue(self::PREFIX . 'TEXT', '');
+        Configuration::updateValue(self::PREFIX . 'ACCEPT_TEXT', '');
+        Configuration::updateValue(self::PREFIX . 'DECLINE_TEXT', '');
+        Configuration::updateValue(self::PREFIX . 'BG', '');
+        Configuration::updateValue(self::PREFIX . 'TEXT_COLOR', '');
+        Configuration::updateValue(self::PREFIX . 'ACCEPT_TEXT_COLOR', '');
+        Configuration::updateValue(self::PREFIX . 'DECLINE_TEXT_COLOR', '');
+        Configuration::updateValue(self::PREFIX . 'BTN_COLOR', '');
+        Configuration::updateValue(self::PREFIX . 'POSITION', '');
+
+        return parent::install() &&
+            $this->registerHook('header') &&
+            $this->registerHook('displayBackOfficeHeader');
+    }
+
+    public function uninstall()
+    {
+        Configuration::deleteByName(self::PREFIX . 'TEXT');
+        Configuration::deleteByName(self::PREFIX . 'ACCEPT_TEXT');
+        Configuration::deleteByName(self::PREFIX . 'DECLINE_TEXT');
+        Configuration::deleteByName(self::PREFIX . 'BG');
+        Configuration::deleteByName(self::PREFIX . 'TEXT_COLOR');
+        Configuration::deleteByName(self::PREFIX . 'ACCEPT_TEXT_COLOR');
+        Configuration::deleteByName(self::PREFIX . 'DECLINE_TEXT_COLOR');
+        Configuration::deleteByName(self::PREFIX . 'BTN_COLOR');
+        Configuration::deleteByName(self::PREFIX . 'POSITION');
+
+        return parent::uninstall();
+    }
+
+    /**
+     * Load the configuration form
+     */
+    public function getContent()
+    {
+        $output = '';
+
+        if (Tools::isSubmit('submit_cookiebanner_config')) {
+            Configuration::updateValue(self::PREFIX . 'TEXT', Tools::getValue(self::PREFIX . 'TEXT'));
+            Configuration::updateValue(self::PREFIX . 'ACCEPT_TEXT', Tools::getValue(self::PREFIX . 'ACCEPT_TEXT'));
+            Configuration::updateValue(self::PREFIX . 'DECLINE_TEXT', Tools::getValue(self::PREFIX . 'DECLINE_TEXT'));
+            Configuration::updateValue(self::PREFIX . 'BG', Tools::getValue(self::PREFIX . 'BG'));
+            Configuration::updateValue(self::PREFIX . 'TEXT_COLOR', Tools::getValue(self::PREFIX . 'TEXT_COLOR'));
+            Configuration::updateValue(self::PREFIX . 'ACCEPT_TEXT_COLOR', Tools::getValue(self::PREFIX . 'ACCEPT_TEXT_COLOR'));
+            Configuration::updateValue(self::PREFIX . 'DECLINE_TEXT_COLOR', Tools::getValue(self::PREFIX . 'DECLINE_TEXT_COLOR'));
+            Configuration::updateValue(self::PREFIX . 'BTN_COLOR', Tools::getValue(self::PREFIX . 'BTN_COLOR'));
+            Configuration::updateValue(self::PREFIX . 'POSITION', Tools::getValue(self::PREFIX . 'POSITION'));
+
+            $output .= $this->displayConfirmation($this->l('Settings updated'));
+        }
+
+        $output .= $this->renderForm();
+        return $output;
+    }
+
+    /**
+     * Create the form that will be displayed in the configuration of your module.
+     */
+    public function renderForm()
+    {
+        $default_lang = (int)Configuration::get('PS_LANG_DEFAULT');
+
+        $fields_form[0]['form'] = [
+            'legend' => [
+                'title' => $this->l('Banner Settings'),
+            ],
+            'input' => [
+                [
+                    'type' => 'textarea',
+                    'label' => $this->l('Banner Text'),
+                    'name' => self::PREFIX . 'TEXT',
+                    'required' => true,
+                ],
+                [
+                    'type' => 'text',
+                    'label' => $this->l('Accept Button Text'),
+                    'name' => self::PREFIX . 'ACCEPT_TEXT',
+                    'required' => true,
+                ],
+                [
+                    'type' => 'text',
+                    'label' => $this->l('Decline Button Text'),
+                    'name' => self::PREFIX . 'DECLINE_TEXT',
+                    'required' => true,
+                ],
+                [
+                    'type' => 'color',
+                    'label' => $this->l('Background Color'),
+                    'name' => self::PREFIX . 'BG',
+                    'required' => true,
+                ],
+                [
+                    'type' => 'color',
+                    'label' => $this->l('Text Color'),
+                    'name' => self::PREFIX . 'TEXT_COLOR',
+                    'required' => true,
+                ],
+                [
+                    'type' => 'color',
+                    'label' => $this->l('Accept Button Color'),
+                    'name' => self::PREFIX . 'ACCEPT_TEXT_COLOR',
+                    'required' => true,
+                ],
+                [
+                    'type' => 'color',
+                    'label' => $this->l('Decline Button Color'),
+                    'name' => self::PREFIX . 'DECLINE_TEXT_COLOR',
+                    'required' => true,
+                ],
+                [
+                    'type' => 'color',
+                    'label' => $this->l('Button Color'),
+                    'name' => self::PREFIX . 'BTN_COLOR',
+                    'required' => true,
+                ],
+                [
+                    'type' => 'select',
+                    'label' => $this->l('Banner Position'),
+                    'name' => self::PREFIX . 'POSITION',
+                    'options' => [
+                        'query' => [
+                            ['id' => 'top', 'name' => $this->l('Top')],
+                            ['id' => 'bottom', 'name' => $this->l('Bottom')],
+                            ['id' => 'popup', 'name' => $this->l('Popup')],
+                        ],
+                        'id' => 'id',
+                        'name' => 'name'
+                    ],
+                    'required' => true,
+                ],
+            ],
+            'submit' => [
+                'title' => $this->l('Save'),
+                'class' => 'btn btn-default pull-right'
+            ]
+        ];
+
+        $helper = new HelperForm();
+        $helper->module = $this;
+        $helper->name_controller = $this->name;
+        $helper->token = Tools::getAdminTokenLite('AdminModules');
+        $helper->currentIndex = AdminController::$currentIndex.'&configure='.$this->name;
+        $helper->default_form_language = $default_lang;
+        $helper->allow_employee_form_lang = $default_lang;
+        $helper->title = $this->displayName;
+        $helper->show_cancel_button = false;
+        $helper->submit_action = 'submit_cookiebanner_config';
+
+        // Load current values
+        $helper->fields_value[self::PREFIX . 'TEXT'] = Configuration::get(self::PREFIX . 'TEXT');
+        $helper->fields_value[self::PREFIX . 'ACCEPT_TEXT'] = Configuration::get(self::PREFIX . 'ACCEPT_TEXT');
+        $helper->fields_value[self::PREFIX . 'DECLINE_TEXT'] = Configuration::get(self::PREFIX . 'DECLINE_TEXT');
+        $helper->fields_value[self::PREFIX . 'BG'] = Configuration::get(self::PREFIX . 'BG');
+        $helper->fields_value[self::PREFIX . 'TEXT_COLOR'] = Configuration::get(self::PREFIX . 'TEXT_COLOR');
+        $helper->fields_value[self::PREFIX . 'ACCEPT_TEXT_COLOR'] = Configuration::get(self::PREFIX . 'ACCEPT_TEXT_COLOR');
+        $helper->fields_value[self::PREFIX . 'DECLINE_TEXT_COLOR'] = Configuration::get(self::PREFIX . 'DECLINE_TEXT_COLOR');
+        $helper->fields_value[self::PREFIX . 'BTN_COLOR'] = Configuration::get(self::PREFIX . 'BTN_COLOR');
+        $helper->fields_value[self::PREFIX . 'POSITION'] = Configuration::get(self::PREFIX . 'POSITION');
+
+        return $helper->generateForm($fields_form);
+    }
+
+    /**
+    * Add the CSS & JavaScript files you want to be loaded in the BO.
+    */
+    public function hookDisplayBackOfficeHeader()
+    {
+        if (Tools::getValue('configure') == $this->name) {
+            $this->context->controller->addJS($this->_path.'views/js/back.js');
+            $this->context->controller->addCSS($this->_path.'views/css/back.css');
+        }
+    }
+
+    /**
+     * Add the CSS & JavaScript files you want to be added on the FO.
+     */
+    public function hookHeader()
+    {
+        $this->context->controller->addJS($this->_path.'/views/js/front.js');
+        $this->context->controller->addCSS($this->_path.'/views/css/front.css');
+    }
+}

--- a/modules/cookiebanner/cookiebanner.php
+++ b/modules/cookiebanner/cookiebanner.php
@@ -244,6 +244,9 @@ class Cookiebanner extends Module
 
     public function hookDisplayFooter($params)
     {
+        if ($this->context->cookie->cookie_consent)
+            return '';
+
         $config = $this->getModuleConfigValues();
 
         $this->context->smarty->assign([

--- a/modules/cookiebanner/cookiebanner.php
+++ b/modules/cookiebanner/cookiebanner.php
@@ -68,12 +68,13 @@ class Cookiebanner extends Module
         Configuration::updateValue(self::PREFIX . 'TEXT_COLOR', '');
         Configuration::updateValue(self::PREFIX . 'ACCEPT_TEXT_COLOR', '');
         Configuration::updateValue(self::PREFIX . 'DECLINE_TEXT_COLOR', '');
-        Configuration::updateValue(self::PREFIX . 'BTN_COLOR', '');
+        Configuration::updateValue(self::PREFIX . 'ACCEPT_BTN_COLOR', '');
+        Configuration::updateValue(self::PREFIX . 'DECLINE_BTN_COLOR', '');
         Configuration::updateValue(self::PREFIX . 'POSITION', '');
 
         return parent::install() &&
             $this->registerHook('header') &&
-            $this->registerHook('displayBackOfficeHeader');
+            $this->registerHook('displayFooter');
     }
 
     public function uninstall()
@@ -85,7 +86,8 @@ class Cookiebanner extends Module
         Configuration::deleteByName(self::PREFIX . 'TEXT_COLOR');
         Configuration::deleteByName(self::PREFIX . 'ACCEPT_TEXT_COLOR');
         Configuration::deleteByName(self::PREFIX . 'DECLINE_TEXT_COLOR');
-        Configuration::deleteByName(self::PREFIX . 'BTN_COLOR');
+        Configuration::deleteByName(self::PREFIX . 'ACCEPT_BTN_COLOR');
+        Configuration::deleteByName(self::PREFIX . 'DECLINE_BTN_COLOR', '');
         Configuration::deleteByName(self::PREFIX . 'POSITION');
 
         return parent::uninstall();
@@ -106,7 +108,8 @@ class Cookiebanner extends Module
             Configuration::updateValue(self::PREFIX . 'TEXT_COLOR', Tools::getValue(self::PREFIX . 'TEXT_COLOR'));
             Configuration::updateValue(self::PREFIX . 'ACCEPT_TEXT_COLOR', Tools::getValue(self::PREFIX . 'ACCEPT_TEXT_COLOR'));
             Configuration::updateValue(self::PREFIX . 'DECLINE_TEXT_COLOR', Tools::getValue(self::PREFIX . 'DECLINE_TEXT_COLOR'));
-            Configuration::updateValue(self::PREFIX . 'BTN_COLOR', Tools::getValue(self::PREFIX . 'BTN_COLOR'));
+            Configuration::updateValue(self::PREFIX . 'ACCEPT_BTN_COLOR', Tools::getValue(self::PREFIX . 'ACCEPT_BTN_COLOR'));
+            Configuration::updateValue(self::PREFIX . 'DECLINE_BTN_COLOR', Tools::getValue(self::PREFIX . 'DECLINE_BTN_COLOR'));
             Configuration::updateValue(self::PREFIX . 'POSITION', Tools::getValue(self::PREFIX . 'POSITION'));
 
             $output .= $this->displayConfirmation($this->l('Settings updated'));
@@ -160,20 +163,26 @@ class Cookiebanner extends Module
                 ],
                 [
                     'type' => 'color',
-                    'label' => $this->l('Accept Button Color'),
+                    'label' => $this->l('Accept Text Color'),
                     'name' => self::PREFIX . 'ACCEPT_TEXT_COLOR',
                     'required' => true,
                 ],
                 [
                     'type' => 'color',
-                    'label' => $this->l('Decline Button Color'),
+                    'label' => $this->l('Decline Text Color'),
                     'name' => self::PREFIX . 'DECLINE_TEXT_COLOR',
                     'required' => true,
                 ],
                 [
                     'type' => 'color',
-                    'label' => $this->l('Button Color'),
-                    'name' => self::PREFIX . 'BTN_COLOR',
+                    'label' => $this->l('Accept Button Color'),
+                    'name' => self::PREFIX . 'ACCEPT_BTN_COLOR',
+                    'required' => true,
+                ],
+                [
+                    'type' => 'color',
+                    'label' => $this->l('Decline Button Color'),
+                    'name' => self::PREFIX . 'DECLINE_BTN_COLOR',
                     'required' => true,
                 ],
                 [
@@ -217,21 +226,11 @@ class Cookiebanner extends Module
         $helper->fields_value[self::PREFIX . 'TEXT_COLOR'] = Configuration::get(self::PREFIX . 'TEXT_COLOR');
         $helper->fields_value[self::PREFIX . 'ACCEPT_TEXT_COLOR'] = Configuration::get(self::PREFIX . 'ACCEPT_TEXT_COLOR');
         $helper->fields_value[self::PREFIX . 'DECLINE_TEXT_COLOR'] = Configuration::get(self::PREFIX . 'DECLINE_TEXT_COLOR');
-        $helper->fields_value[self::PREFIX . 'BTN_COLOR'] = Configuration::get(self::PREFIX . 'BTN_COLOR');
+        $helper->fields_value[self::PREFIX . 'ACCEPT_BTN_COLOR'] = Configuration::get(self::PREFIX . 'ACCEPT_BTN_COLOR');
+        $helper->fields_value[self::PREFIX . 'DECLINE_BTN_COLOR'] = Configuration::get(self::PREFIX . 'DECLINE_BTN_COLOR');
         $helper->fields_value[self::PREFIX . 'POSITION'] = Configuration::get(self::PREFIX . 'POSITION');
 
         return $helper->generateForm($fields_form);
-    }
-
-    /**
-    * Add the CSS & JavaScript files you want to be loaded in the BO.
-    */
-    public function hookDisplayBackOfficeHeader()
-    {
-        if (Tools::getValue('configure') == $this->name) {
-            $this->context->controller->addJS($this->_path.'views/js/back.js');
-            $this->context->controller->addCSS($this->_path.'views/css/back.css');
-        }
     }
 
     /**
@@ -242,4 +241,31 @@ class Cookiebanner extends Module
         $this->context->controller->addJS($this->_path.'/views/js/front.js');
         $this->context->controller->addCSS($this->_path.'/views/css/front.css');
     }
+
+    public function hookDisplayFooter($params)
+    {
+        $config = $this->getModuleConfigValues();
+
+        $this->context->smarty->assign([
+            'config' => $config,
+        ]);
+
+        return $this->display(__FILE__, 'views/templates/hook/footer.tpl');
+    }
+
+    public function getModuleConfigValues()
+{
+    return [
+        'text'                      => Configuration::get(self::PREFIX . 'TEXT'),
+        'accept_text'               => Configuration::get(self::PREFIX . 'ACCEPT_TEXT'),
+        'decline_text'              => Configuration::get(self::PREFIX . 'DECLINE_TEXT'),
+        'bg'                        => Configuration::get(self::PREFIX . 'BG'),
+        'text_color'                => Configuration::get(self::PREFIX . 'TEXT_COLOR'),
+        'accept_text_color'         => Configuration::get(self::PREFIX . 'ACCEPT_TEXT_COLOR'),
+        'decline_text_color'        => Configuration::get(self::PREFIX . 'DECLINE_TEXT_COLOR'),
+        'accept_btn_color'          => Configuration::get(self::PREFIX . 'ACCEPT_BTN_COLOR'),
+        'decline_btn_color'         => Configuration::get(self::PREFIX . 'DECLINE_BTN_COLOR'),
+        'position'                  => Configuration::get(self::PREFIX . 'POSITION'),
+    ];
+}
 }

--- a/modules/cookiebanner/index.php
+++ b/modules/cookiebanner/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/modules/cookiebanner/sql/index.php
+++ b/modules/cookiebanner/sql/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/modules/cookiebanner/sql/install.php
+++ b/modules/cookiebanner/sql/install.php
@@ -1,0 +1,37 @@
+<?php
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+$sql = array();
+
+$sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'cookiebanner` (
+    `id_cookiebanner` int(11) NOT NULL AUTO_INCREMENT,
+    PRIMARY KEY  (`id_cookiebanner`)
+) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8;';
+
+foreach ($sql as $query) {
+    if (Db::getInstance()->execute($query) == false) {
+        return false;
+    }
+}

--- a/modules/cookiebanner/sql/uninstall.php
+++ b/modules/cookiebanner/sql/uninstall.php
@@ -1,0 +1,38 @@
+<?php
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+
+/**
+ * In some cases you should not drop the tables.
+ * Maybe the merchant will just try to reset the module
+ * but does not want to loose all of the data associated to the module.
+ */
+$sql = array();
+
+foreach ($sql as $query) {
+    if (Db::getInstance()->execute($query) == false) {
+        return false;
+    }
+}

--- a/modules/cookiebanner/translations/index.php
+++ b/modules/cookiebanner/translations/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/modules/cookiebanner/upgrade/index.php
+++ b/modules/cookiebanner/upgrade/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/modules/cookiebanner/upgrade/upgrade-1.1.0.php
+++ b/modules/cookiebanner/upgrade/upgrade-1.1.0.php
@@ -1,0 +1,43 @@
+<?php
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * This function updates your module from previous versions to the version 1.1,
+ * usefull when you modify your database, or register a new hook ...
+ * Don't forget to create one file per version.
+ */
+function upgrade_module_1_1_0($module)
+{
+    /*
+     * Do everything you want right there,
+     * You could add a column in one of your module's tables
+     */
+
+    return true;
+}

--- a/modules/cookiebanner/views/css/back.css
+++ b/modules/cookiebanner/views/css/back.css
@@ -1,0 +1,27 @@
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*
+* Don't forget to prefix your containers with your own identifier
+* to avoid any conflicts with others containers.
+*/

--- a/modules/cookiebanner/views/css/front.css
+++ b/modules/cookiebanner/views/css/front.css
@@ -1,0 +1,27 @@
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*
+* Don't forget to prefix your containers with your own identifier
+* to avoid any conflicts with others containers.
+*/

--- a/modules/cookiebanner/views/css/front.css
+++ b/modules/cookiebanner/views/css/front.css
@@ -25,3 +25,22 @@
 * Don't forget to prefix your containers with your own identifier
 * to avoid any conflicts with others containers.
 */
+
+#cookie-banner {
+    left: 0;
+    z-index: 1050;
+    position: fixed;
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    align-items: center;
+}
+
+#popup-cookie-banner-container {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 1040;
+}

--- a/modules/cookiebanner/views/css/index.php
+++ b/modules/cookiebanner/views/css/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/modules/cookiebanner/views/img/index.php
+++ b/modules/cookiebanner/views/img/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/modules/cookiebanner/views/index.php
+++ b/modules/cookiebanner/views/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/modules/cookiebanner/views/js/back.js
+++ b/modules/cookiebanner/views/js/back.js
@@ -1,0 +1,27 @@
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*
+* Don't forget to prefix your containers with your own identifier
+* to avoid any conflicts with others containers.
+*/

--- a/modules/cookiebanner/views/js/front.js
+++ b/modules/cookiebanner/views/js/front.js
@@ -1,0 +1,27 @@
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*
+* Don't forget to prefix your containers with your own identifier
+* to avoid any conflicts with others containers.
+*/

--- a/modules/cookiebanner/views/js/index.php
+++ b/modules/cookiebanner/views/js/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/modules/cookiebanner/views/templates/admin/configure.tpl
+++ b/modules/cookiebanner/views/templates/admin/configure.tpl
@@ -1,0 +1,48 @@
+{*
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*}
+
+<div class="panel">
+	<h3><i class="icon icon-credit-card"></i> {l s='Cookie banner' mod='cookiebanner'}</h3>
+	<p>
+		<strong>{l s='Here is my new generic module!' mod='cookiebanner'}</strong><br />
+		{l s='Thanks to PrestaShop, now I have a great module.' mod='cookiebanner'}<br />
+		{l s='I can configure it using the following configuration form.' mod='cookiebanner'}
+	</p>
+	<br />
+	<p>
+		{l s='This module will boost your sales!' mod='cookiebanner'}
+	</p>
+</div>
+
+<div class="panel">
+	<h3><i class="icon icon-tags"></i> {l s='Documentation' mod='cookiebanner'}</h3>
+	<p>
+		&raquo; {l s='You can get a PDF documentation to configure this module' mod='cookiebanner'} :
+		<ul>
+			<li><a href="#" target="_blank">{l s='English' mod='cookiebanner'}</a></li>
+			<li><a href="#" target="_blank">{l s='French' mod='cookiebanner'}</a></li>
+		</ul>
+	</p>
+</div>

--- a/modules/cookiebanner/views/templates/admin/index.php
+++ b/modules/cookiebanner/views/templates/admin/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/modules/cookiebanner/views/templates/hook/footer.tpl
+++ b/modules/cookiebanner/views/templates/hook/footer.tpl
@@ -1,0 +1,57 @@
+{if $config.position == 'popup'}
+    <div id="popup-cookie-banner-container" style="background-color:rgba(0, 0, 0, 0.5);">
+        <div id="cookie-banner" class="p-2" style="background-color: {$config.bg}; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+            <div style="color: {$config.text_color};">
+                {$config.text}
+            </div>
+            <div class="mt-2">
+                <button id="cookie-accept" class="btn mr-2" style="background-color: {$config.accept_btn_color}; color: {$config.accept_text_color};">{$config.accept_text}</button>
+                <button id="cookie-decline" class="btn" style="background-color: {$config.decline_btn_color}; color: {$config.decline_text_color};">{$config.decline_text}</button>
+            </div>
+        </div>
+    </div>
+    
+{else}
+
+    <div id="cookie-banner" class="w-100 p-2" style="background-color: {$config.bg}; {if $config.position == 'top'} top: 0; {else} bottom: 0;{/if} ">
+        <div style="color: {$config.text_color};">
+            {$config.text}
+        </div>
+        <div class="mt-2">
+            <button id="cookie-accept" class="btn mr-2" style="background-color: {$config.accept_btn_color}; color: {$config.accept_text_color};">{$config.accept_text}</button>
+            <button id="cookie-decline" class="btn" style="background-color: {$config.decline_btn_color}; color: {$config.decline_text_color};">{$config.decline_text}</button>
+        </div>
+    </div>
+    
+{/if}
+
+{literal}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    var banner = document.getElementById('cookie-banner');
+    var accept = document.getElementById('cookie-accept');
+    var decline = document.getElementById('cookie-decline');
+    var popup = document.getElementById('popup-cookie-banner-container');
+
+    // Show banner only if not already accepted/declined
+    if (localStorage.getItem('cookie_consent') === null) {
+        banner.style.display = 'flex';
+        popup ? popup.style.display = 'flex' : null;
+    } else {
+        banner.style.display = 'none';
+        popup ? popup.style.display = 'none' : null;
+    }
+
+    accept.onclick = function() {
+        localStorage.setItem('cookie_consent', 'accepted');
+        banner.style.display = 'none';
+        popup ? popup.style.display = 'none' : null;
+    };
+    decline.onclick = function() {
+        localStorage.setItem('cookie_consent', 'declined');
+        banner.style.display = 'none';
+        popup ? popup.style.display = 'none' : null;
+    };
+});
+</script>
+{/literal}

--- a/modules/cookiebanner/views/templates/hook/footer.tpl
+++ b/modules/cookiebanner/views/templates/hook/footer.tpl
@@ -28,30 +28,34 @@
 {literal}
 <script>
 document.addEventListener('DOMContentLoaded', function() {
-    var banner = document.getElementById('cookie-banner');
-    var accept = document.getElementById('cookie-accept');
-    var decline = document.getElementById('cookie-decline');
-    var popup = document.getElementById('popup-cookie-banner-container');
+    var cookieSaveUrl = '{/literal}{$link->getModuleLink('cookiebanner', 'savecookie', [], true)}{literal}';
 
-    // Show banner only if not already accepted/declined
-    if (localStorage.getItem('cookie_consent') === null) {
-        banner.style.display = 'flex';
-        popup ? popup.style.display = 'flex' : null;
-    } else {
-        banner.style.display = 'none';
-        popup ? popup.style.display = 'none' : null;
+    var banner = $('#cookie-banner');
+    var accept = $('#cookie-accept');
+    var decline = $('#cookie-decline');
+    var popup = $('#popup-cookie-banner-container');
+
+    function handleConsent(consentValue) {
+        $.ajax({
+            url: cookieSaveUrl,
+            type: 'POST',
+            data: { consent: consentValue },
+            success: function(response) {
+                banner.hide();
+                if (typeof popup !== 'undefined' && popup !== null) {
+                    popup.hide();
+                }
+            }
+        });
     }
 
-    accept.onclick = function() {
-        localStorage.setItem('cookie_consent', 'accepted');
-        banner.style.display = 'none';
-        popup ? popup.style.display = 'none' : null;
-    };
-    decline.onclick = function() {
-        localStorage.setItem('cookie_consent', 'declined');
-        banner.style.display = 'none';
-        popup ? popup.style.display = 'none' : null;
-    };
+    accept.on('click', function() {
+        handleConsent('accepted');
+    });
+
+    decline.on('click', function() {
+        handleConsent('declined');
+    });
 });
 </script>
 {/literal}

--- a/modules/cookiebanner/views/templates/index.php
+++ b/modules/cookiebanner/views/templates/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+* 2007-2025 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2025 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;


### PR DESCRIPTION
### Resumen
Agregar nuevo módulo cookiebanner para PrestaShop 8, que permite mostrar un banner de cookies configurable en la tienda.
### Funcionalidades
- Banner de cookies con botones de aceptar y rechazar.
- Configuración del texto, color de fondo, color del texto, color del botón y posición del banner desde el back office.
- Opción para activar o desactivar la visibilidad del banner.
- Almacenamiento del consentimiento del usuario mediante AJAX y cookie.
### Cómo usar
- Instalar el módulo cookiebanner desde el back office.
- Configurar los textos, colores, posición y visibilidad del banner en la página de configuración del módulo..
- El banner aparecerá en la tienda según la configuración seleccionada.